### PR TITLE
Using [0X-XX] in hostname pattern

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
-	"strings"
 )
 
 const (
@@ -181,20 +180,16 @@ func saveOutputFile(filePath string, browsers XmlBrowsers) error {
 func parseHostPattern(pattern string) []string {
 	re := regexp.MustCompile("(.*)\\[(\\d+):(\\d+)\\](.*)")
 	pieces := re.FindStringSubmatch(pattern)
-	nullPrefix := ""
 	if len(pieces) == 5 {
 		head := pieces[1]
 		from, _ := strconv.Atoi(pieces[2])
 		to, _ := strconv.Atoi(pieces[3])
 		tail := pieces[4]
+		hostnameFmt := fmt.Sprintf("%%s%%0%dd%%s", len(pieces[2]))
 		if from <= to {
 			ret := []string{}
 			for i := from; i <= to; i++ {
-				nullPrefix = ""
-				if strings.HasPrefix(pieces[2], "0") && i < 10 {
-					nullPrefix = "0"
-				}
-				ret = append(ret, fmt.Sprintf("%s%s%d%s", head, nullPrefix, i, tail))
+				ret = append(ret, fmt.Sprintf(hostnameFmt, head, i, tail))
 			}
 			return ret
 		}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -180,6 +181,7 @@ func saveOutputFile(filePath string, browsers XmlBrowsers) error {
 func parseHostPattern(pattern string) []string {
 	re := regexp.MustCompile("(.*)\\[(\\d+):(\\d+)\\](.*)")
 	pieces := re.FindStringSubmatch(pattern)
+	nullPrefix := ""
 	if len(pieces) == 5 {
 		head := pieces[1]
 		from, _ := strconv.Atoi(pieces[2])
@@ -188,7 +190,11 @@ func parseHostPattern(pattern string) []string {
 		if from <= to {
 			ret := []string{}
 			for i := from; i <= to; i++ {
-				ret = append(ret, fmt.Sprintf("%s%d%s", head, i, tail))
+				nullPrefix = ""
+				if (strings.HasPrefix(pieces[2], "0") && i < 10)  {
+					nullPrefix = "0"
+				}
+				ret = append(ret, fmt.Sprintf("%s%s%d%s", head, nullPrefix, i, tail))
 			}
 			return ret
 		}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -191,7 +191,7 @@ func parseHostPattern(pattern string) []string {
 			ret := []string{}
 			for i := from; i <= to; i++ {
 				nullPrefix = ""
-				if (strings.HasPrefix(pieces[2], "0") && i < 10)  {
+				if strings.HasPrefix(pieces[2], "0") && i < 10 {
 					nullPrefix = "0"
 				}
 				ret = append(ret, fmt.Sprintf("%s%s%d%s", head, nullPrefix, i, tail))

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -18,6 +18,7 @@ func TestParseHostPattern(t *testing.T) {
 	AssertThat(t, parseHostPattern("test[1:3]-host"), EqualTo{[]string{"test1-host", "test2-host", "test3-host"}})
 	AssertThat(t, parseHostPattern("[1:3]-host"), EqualTo{[]string{"1-host", "2-host", "3-host"}})
 	AssertThat(t, parseHostPattern("host-[1:3]"), EqualTo{[]string{"host-1", "host-2", "host-3"}})
+	AssertThat(t, parseHostPattern("host-[01:03]"), EqualTo{[]string{"host-01", "host-02", "host-03"}})
 }
 
 func TestConvert(t *testing.T) {


### PR DESCRIPTION
If pattern contains `[01:10]`

**By example**

```
selenoid[01:10].example.com
```

Hostnames in output xml will be generate without `0`
```yaml
selenoid1.example.com
selenoid2.example.com
...
selenoid10.example.com
```

This PR solve it. In this case you'll get:

```yaml
selenoid01.example.com
selenoid02.example.com
...
selenoid10.example.com
```

There is backward compatible fix.